### PR TITLE
Revert back to lmos-ai version as long as no new chart is published

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -41,7 +41,7 @@ while ! kubectl get crd agents.lmos.eclipse >/dev/null 2>/dev/null; do sleep 1; 
 echo "LMOS agent CRD created."
 
 # Install arc-view chart
-helm upgrade --install arc-view-runtime-web oci://ghcr.io/eclipse-lmos/arc-view-runtime-web-chart --version 0.1.0-SNAPSHOT
+helm upgrade --install arc-view-runtime-web oci://ghcr.io/lmos-ai/arc-view-runtime-web-chart --version 0.1.0
 
 # Wait for pods to be running
 echo "Waiting for pods to be running..."


### PR DESCRIPTION
@patwlan & @dharam1291, do you know where the arc-view-runtime-web-chart was built? I couldn't see anything in the arc-view repo, so this artifact is still missing for eclipse-lmos...