### PR TITLE
Update license headers to 2025 and include "and others"

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ This project has adopted the [Contributor Covenant](https://www.contributor-cove
 By participating in this project, you agree to abide by its [Code of Conduct](./CODE_OF_CONDUCT.md) at all times.
 
 ## Licensing
-Copyright (c) 2024 Deutsche Telekom AG.
+Copyright (c) 2025 Deutsche Telekom AG and others.
 
 Sourcecode licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) (the "License"); you may not use this project except in compliance with the License.
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 # 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -13,7 +13,7 @@ path = [
     "argocd-apps/*.yaml",
     "istio/*.yaml"
 ]
-SPDX-FileCopyrightText = "2024 Deutsche Telekom AG"
+SPDX-FileCopyrightText = "2025 Deutsche Telekom AG and others"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]

--- a/demos/product-recommender/install.sh
+++ b/demos/product-recommender/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/demos/product-recommender/product-recommender-channel.yml
+++ b/demos/product-recommender/product-recommender-channel.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/demos/starter/acme-web-stable-channel.yml
+++ b/demos/starter/acme-web-stable-channel.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/demos/starter/install.sh
+++ b/demos/starter/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/init/start_minikube.sh
+++ b/init/start_minikube.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/test_runtime.sh
+++ b/test_runtime.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
See https://www.eclipse.org/projects/handbook/#ip-copyright-headers